### PR TITLE
Remove indent-raibow as default plugin in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,6 @@
                 "Gruntfuggly.todo-tree",
                 "charliermarsh.ruff",
                 "tamasfe.even-better-toml",
-                "oderwat.indent-rainbow",
                 "yzhang.markdown-all-in-one",
                 "ionutvmi.path-autocomplete",
                 "eamodio.gitlens",


### PR DESCRIPTION
## Overview

- remove indent-rainbow as default plugin in devcontainer