### PR TITLE
Add installation of ssh when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt update -y \
     tzdata \
     sudo \
     git \
+    ssh \
     vim \
     # for opencv \
     libgl1-mesa-dev


### PR DESCRIPTION
## Overview

- For git, I install openssh via apt when building docker image