### PR TITLE
Fix/module-deleted-20

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -13,6 +13,7 @@ from matplotlib import axes, figure
 from matplotlib import pyplot as plt
 from timm.utils import model_ema
 from torch.amp import grad_scaler
+from torch.optim.optimizer import Optimizer
 from typing_extensions import NotRequired
 
 from src import optim, utils
@@ -145,7 +146,7 @@ CKPT = FullCKPT | WeightOnlyCKPT
 
 def make_checkpoints(
     model: nn.Module,
-    optimizer: torch.optim.optimizer.Optimizer,
+    optimizer: Optimizer,
     scheduler: optim.Schedulers,
     scaler: grad_scaler.GradScaler,
     epoch: int,
@@ -165,7 +166,7 @@ def make_checkpoints(
 
 def load_checkpoints(
     model: nn.Module,
-    optimizer: torch.optim.optimizer.Optimizer,
+    optimizer: Optimizer,
     scheduler: optim.Schedulers,
     scaler: grad_scaler.GradScaler,
     checkpoint: FullCKPT,
@@ -289,7 +290,7 @@ class MetricsMonitor:
 def step(
     step: int,
     model: nn.Module,
-    optimizer: torch.optim.optimizer.Optimizer,
+    optimizer: Optimizer,
     loss: torch.Tensor,
     max_norm: float | None = None,
     scaler: grad_scaler.GradScaler | None = None,
@@ -305,7 +306,7 @@ def step(
     Args:
         step : step number
         model : nn.Module
-        optimizer : torch.optim.optimizer.Optimizer
+        optimizer : Optimizer
         loss : loss tensor
         max_norm : If not None, clip grad norm. Default is None. If None, not clip grad norm
         scaler : If not None, use scaler.step() and scaler.update()

--- a/src/exp/exp000/train.py
+++ b/src/exp/exp000/train.py
@@ -7,6 +7,7 @@ import torch.utils.data as torch_data
 import wandb
 from timm.utils import model_ema
 from torch.amp import autocast_mode, grad_scaler
+from torch.optim.optimizer import Optimizer
 from tqdm.auto import tqdm
 
 from src import constants, engine, log, metrics, optim, utils
@@ -33,7 +34,7 @@ def train_one_epoch(
     epoch: int,
     model: nn.Module,
     ema_model: model_ema.ModelEmaV3 | None,
-    optimizer: torch.optim.optimizer.Optimizer,
+    optimizer: Optimizer,
     scheduler: optim.Schedulers,
     criterion: my_loss.LossFn,
     loader: torch_data.DataLoader[dataset.TrainBatch],
@@ -48,7 +49,7 @@ def train_one_epoch(
         epoch: number of epoch
         model: model to train
         ema_model: ema_model.ModelEmaV3
-        optimizer: torch.optim.Optimizer. I almost use AdamW.
+        optimizer: torch.optim.optimizer.Optimizer. I almost use AdamW.
         scheduler: optim.Schedulers. I almost use transformers.get_cosine_schedule_with_warmup
         criterion: LossFn. see get_loss_fn.
         loader: torch_data.DataLoader for training set

--- a/src/optim.py
+++ b/src/optim.py
@@ -4,6 +4,8 @@ from typing import Any, Literal, TypeAlias, overload
 import torch
 import transformers
 from torch.optim import lr_scheduler
+from torch.optim.adamw import AdamW
+from torch.optim.optimizer import Optimizer
 
 logger = getLogger(__name__)
 
@@ -28,9 +30,7 @@ def get_params_no_decay(
     return params
 
 
-def get_optimizer(
-    optimizer_name: str, optmizer_params: dict[str, Any], model: torch.nn.Module
-) -> torch.optim.Optimizer:
+def get_optimizer(optimizer_name: str, optmizer_params: dict[str, Any], model: torch.nn.Module) -> Optimizer:
     """Get optimizer from optimizer name
 
     Args:
@@ -43,7 +43,7 @@ def get_optimizer(
     """
     if optimizer_name == "AdamW":
         model_params = get_params_no_decay(model, weight_decay=optmizer_params["weight_decay"])
-        optimizer = torch.optim.AdamW(model_params, **optmizer_params)
+        optimizer = AdamW(model_params, **optmizer_params)
         return optimizer
     raise ValueError(f"Unknown optimizer name: {optimizer_name}")
 
@@ -75,7 +75,7 @@ SchedulersLiteral: TypeAlias = Literal["CosineLRScheduler", "CosineAnnealingWarm
 
 @overload
 def get_scheduler(
-    scheduler_name: Literal["CosineLRScheduler"], scheduler_params: dict[str, Any], optimizer: torch.optim.Optimizer
+    scheduler_name: Literal["CosineLRScheduler"], scheduler_params: dict[str, Any], optimizer: Optimizer
 ) -> lr_scheduler.LambdaLR: ...
 
 
@@ -83,21 +83,21 @@ def get_scheduler(
 def get_scheduler(
     scheduler_name: Literal["CosineAnnealingWarmRestarts"],
     scheduler_params: dict[str, Any],
-    optimizer: torch.optim.Optimizer,
+    optimizer: Optimizer,
 ) -> lr_scheduler.CosineAnnealingWarmRestarts: ...
 
 
 def get_scheduler(
     scheduler_name: SchedulersLiteral,
     scheduler_params: dict[str, Any],
-    optimizer: torch.optim.Optimizer,
+    optimizer: Optimizer,
 ) -> Schedulers:
     """Get scheduler from scheduler name
 
     Args:
         scheduler_name (str): scheduler name
         scheduler_params (dict[str, Any]): scheduler parameters
-        optimizer (torch.optim.Optimizer): optimizer
+        optimizer (torch.optim.optimizer.Optimizer): optimizer
 
     Returns:
         Schedulers: scheduler.

--- a/test/test_optim.py
+++ b/test/test_optim.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import torch.nn as nn
+from torch.optim.optimizer import Optimizer
 
 from src import optim
 
@@ -52,9 +53,7 @@ def test_get_optimizer_should_success(sample_model: nn.Module) -> None:
         optmizer_params={"lr": 0.001, "weight_decay": 1e-5, "eps": 1e-6, "fused": False},
         model=sample_model,
     )
-    assert isinstance(optimizer, torch.optim.Optimizer), (
-        f"E: isinstance(optimizer, torch.optim.Optimizer), A: {type(optimizer)}"
-    )
+    assert isinstance(optimizer, Optimizer), f"E: isinstance(optimizer, Optimizer), A: {type(optimizer)}"
     assert optimizer.__class__.__name__ == "AdamW", (
         f"E: optimizer.__class__.__name__ == 'AdamW', A: {optimizer.__class__.__name__}"
     )


### PR DESCRIPTION
# Overview

feat(typing): Use direct imports for Optimizer and AdamW

Import `Optimizer` directly from `torch.optim.optimizer` instead of `torch.optim.optimizer.Optimizer`.
Import `AdamW` directly from `torch.optim.adamw` instead of `torch.optim.AdamW`.

This change simplifies the type hints and improves code readability by using more direct imports, aligning with common PyTorch practices. No functional changes are introduced.