### PR TITLE
Fix/tiny-bugs-22

### DIFF
--- a/src/exp/exp000/config.py
+++ b/src/exp/exp000/config.py
@@ -68,7 +68,12 @@ class Config(pydantic.BaseModel):
     model_arch: str = "SimpleNN"
     model_params: dict[str, float] = {}
     use_ema: bool = True
-    ema_params: dict[str, float] = {"decal": 0.999, "update_after_step": 100, "use_warmup": True, "warmup_power": 0.75}
+    ema_params: dict[str, float] = {
+        "decay": 0.999,
+        "update_after_step": 100,
+        "use_warmup": True,
+        "warmup_power": 0.75,
+    }
 
 
 class GBDTConfig(pydantic.BaseModel):

--- a/src/exp/exp000/dataset.py
+++ b/src/exp/exp000/dataset.py
@@ -45,7 +45,7 @@ def init_dataloader(
     fold: int = 0,
     debug: bool = False,
     fulltrain: bool = False,
-    prefetch_factor: int | None = None,
+    prefetch_factor: int | None = 2,
     persistent_workers: bool = False,
 ) -> tuple[torch_data.DataLoader, torch_data.DataLoader]:
     if mp.cpu_count() < num_workers:

--- a/src/exp/exp000/dataset.py
+++ b/src/exp/exp000/dataset.py
@@ -113,17 +113,19 @@ def _test_dataloaders() -> None:
         debug=True,
     )
     print("-- Test Train")
-    for i, batch in enumerate(dl_train):
+    train_batch: TrainBatch
+    for i, train_batch in enumerate(dl_train):
         if i > 3:
             break
-        _key, x, y = batch
+        _key, x, y = train_batch
         print(f"{_key=}, {x.shape=}, {y.shape=}")
 
     print("-- Test Valid")
-    for i, batch in enumerate(dl_valid):
+    valid_batch: ValidBatch
+    for i, valid_batch in enumerate(dl_valid):
         if i > 3:
             break
-        _key, x, y = batch
+        _key, x, y = valid_batch
         print(f"{_key=}, {x.shape=}, {y.shape=}")
 
 

--- a/src/exp/exp000/dataset.py
+++ b/src/exp/exp000/dataset.py
@@ -68,11 +68,11 @@ def init_dataloader(
     # --- Preprocess
 
     # --- Construct Datasets
-    train_ds: torch_data.Dataset[TrainBatch] = MyTrainDataset(df_train)
-    valid_ds: torch_data.Dataset[ValidBatch] = MyValidDataset(df_valid)
+    ds_train: torch_data.Dataset[TrainBatch] = MyTrainDataset(df_train)
+    ds_valid: torch_data.Dataset[ValidBatch] = MyValidDataset(df_valid)
     # --- Construct DataLoaders
-    train_dl = torch_data.DataLoader(
-        dataset=train_ds,
+    dl_train = torch_data.DataLoader(
+        dataset=ds_train,
         batch_size=train_batch_size,
         shuffle=True,
         num_workers=num_workers,
@@ -83,8 +83,8 @@ def init_dataloader(
         persistent_workers=True if num_workers > 0 else False,
     )
 
-    valid_loader = torch_data.DataLoader(
-        dataset=valid_ds,
+    dl_valid = torch_data.DataLoader(
+        dataset=ds_valid,
         batch_size=valid_batch_size,
         shuffle=False,
         num_workers=num_workers,
@@ -95,7 +95,7 @@ def init_dataloader(
         persistent_workers=True if num_workers > 0 else False,
     )
 
-    return train_dl, valid_loader
+    return dl_train, dl_valid
 
 
 def _test_dataloaders() -> None:

--- a/src/exp/exp000/dataset.py
+++ b/src/exp/exp000/dataset.py
@@ -6,8 +6,6 @@ import torch
 import torch.utils.data as torch_data
 from typing_extensions import TypeAlias
 
-from src import utils
-
 # =============================================================================
 # Dataset
 # =============================================================================
@@ -47,6 +45,8 @@ def init_dataloader(
     fold: int = 0,
     debug: bool = False,
     fulltrain: bool = False,
+    prefetch_factor: int | None = None,
+    persistent_workers: bool = False,
 ) -> tuple[torch_data.DataLoader, torch_data.DataLoader]:
     if mp.cpu_count() < num_workers:
         num_workers = mp.cpu_count()
@@ -65,6 +65,10 @@ def init_dataloader(
     if debug:
         df_train = df_train.head(100)
         df_valid = df_valid.head(100)
+
+    if fulltrain:
+        df_train = df
+
     # --- Preprocess
 
     # --- Construct Datasets
@@ -78,9 +82,8 @@ def init_dataloader(
         num_workers=num_workers,
         drop_last=True,
         pin_memory=True,
-        prefetch_factor=2 if num_workers > 0 else None,
-        worker_init_fn=lambda _: utils.seed_everything(42),
-        persistent_workers=True if num_workers > 0 else False,
+        prefetch_factor=prefetch_factor,
+        persistent_workers=persistent_workers,
     )
 
     dl_valid = torch_data.DataLoader(
@@ -90,9 +93,8 @@ def init_dataloader(
         num_workers=num_workers,
         drop_last=False,
         pin_memory=True if num_workers > 0 else False,
-        prefetch_factor=2 if num_workers > 0 else None,
-        worker_init_fn=lambda _: utils.seed_everything(42),
-        persistent_workers=True if num_workers > 0 else False,
+        prefetch_factor=prefetch_factor,
+        persistent_workers=persistent_workers,
     )
 
     return dl_train, dl_valid

--- a/src/exp/exp000/models.py
+++ b/src/exp/exp000/models.py
@@ -28,6 +28,7 @@ class CustomModel(nn.Module):
     References:
     1. [数百種類のモデルを備える最強画像認識ライブラリ　「timm」のお手軽な使い方](https://logmi.jp/main/technology/325674)
     """
+
     def __init__(
         self,
         pretrained: bool = True,
@@ -41,7 +42,7 @@ class CustomModel(nn.Module):
         self.backbone = timm.create_model(
             backbone,
             pretrained=pretrained,
-            in_channels=in_channels,
+            in_chans=in_channels,
             num_classes=num_classes,
             features_only=features_only,
         )

--- a/src/exp/exp000/train.py
+++ b/src/exp/exp000/train.py
@@ -70,6 +70,7 @@ def train_one_epoch(
     update_per_epoch = (len(loader) + grad_accum_steps - 1) // grad_accum_steps
     num_updates = update_per_epoch * epoch
 
+    batch: dataset.TrainBatch
     for step, batch in pbar:
         _sample_id, x, y = batch
         x, y = x.to(device, non_blocking=True), y.to(device, non_blocking=True)
@@ -127,6 +128,7 @@ def valid_one_epoch(
     pbar = tqdm(enumerate(loader), total=len(loader), desc="Valid", dynamic_ncols=True)
     loss_meter = engine.AverageMeter("valid/loss")
     oofs: list[pl.DataFrame] = []
+    batch: dataset.ValidBatch
     for batch_idx, batch in pbar:
         sample_id, x, y = batch
         x = x.to(device, non_blocking=True)

--- a/src/exp/exp000/train.py
+++ b/src/exp/exp000/train.py
@@ -76,7 +76,8 @@ def train_one_epoch(
         with autocast_mode.autocast(device_type=device.type, enabled=use_amp, dtype=torch.float16):
             output = model(x)
             y_pred = output
-            loss = criterion(y_pred, y)
+            loss_dict = criterion(y_pred, y)
+            loss = loss_dict["loss"]
 
         # --- Update
         if step % grad_accum_steps == 0:
@@ -133,7 +134,8 @@ def valid_one_epoch(
             output = model(x)
 
         y_pred = output
-        loss = criterion(y_pred, y)
+        loss_dict = criterion(y_pred, y)
+        loss = loss_dict["loss"]
         loss_meter.update(loss.detach().cpu().item())
 
         oofs.append(

--- a/src/loss.py
+++ b/src/loss.py
@@ -4,16 +4,25 @@ from typing import Any, TypeAlias
 import torch
 import torch.nn as nn
 
-LossFn: TypeAlias = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+LossFn: TypeAlias = Callable[[torch.Tensor, torch.Tensor], dict[str, torch.Tensor]]
+"""(pred, target) -> {"loss": loss}"""
+
+
+def wrap_loss_fn(loss_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]) -> LossFn:
+    def wrapped_loss_fn(pred: torch.Tensor, target: torch.Tensor) -> dict[str, torch.Tensor]:
+        loss = loss_fn(pred, target)
+        return {"loss": loss}
+
+    return wrapped_loss_fn
 
 
 def get_loss_fn(loss_name: str, loss_params: dict[str, Any]) -> LossFn:
     if loss_name == "BCEWithLogitsLoss":
-        return nn.BCEWithLogitsLoss(**loss_params)
+        return wrap_loss_fn(nn.BCEWithLogitsLoss(**loss_params))
     if loss_name == "CrossEntropyLoss":
-        return nn.CrossEntropyLoss(**loss_params)
+        return wrap_loss_fn(nn.CrossEntropyLoss(**loss_params))
     if loss_name == "MSELoss":
-        return nn.MSELoss(**loss_params)
+        return wrap_loss_fn(nn.MSELoss(**loss_params))
     if loss_name == "L1Loss":
-        return nn.L1Loss(**loss_params)
+        return wrap_loss_fn(nn.L1Loss(**loss_params))
     raise ValueError(f"Unknown loss name: {loss_name}")


### PR DESCRIPTION
## Overview

This pull request introduces improvements and refactorings across the codebase, primarily aimed at:

*   Correcting typos in configuration values.
*   Enhancing the flexibility of DataLoader configuration.
*   Adapting to API changes in external libraries (timm).
*   Extending the loss function interface to facilitate future feature additions.

## Details

### Configuration File Fix (`src/exp/exp000/config.py`)

*   Corrected the parameter name `decal` to `decay` within `ema_params` in the `Config` class. (Typo fix)

### DataLoader Enhancements (`src/exp/exp000/dataset.py`)

*   Added `prefetch_factor` and `persistent_workers` arguments to the `init_dataloader` function, allowing external configuration for DataLoader performance tuning.
*   Renamed dataset and dataloader variables from `*_ds` -> `ds_*` and `*_dl` -> `dl_*` for improved consistency.
*   Removed the seed fixing logic for each worker process previously done using `worker_init_fn`. If reproducibility is required, separate configuration is needed.
*   Removed the unused import of `src.utils`.

### Model Definition Update (`src/exp/exp000/models.py`)

*   Changed the argument name from `in_channels` to `in_chans` when calling `timm.create_model` within the `CustomModel` class. This aligns with the latest version of the `timm` library.

### Loss Function Refactoring (`src/loss.py`, `src/exp/exp000/train.py`)

*   Modified the return type of the loss function (`LossFn`) from a single tensor to `dict[str, torch.Tensor]`. This allows returning values other than the primary loss (e.g., auxiliary losses, calculated metrics), enhancing extensibility.
*   Introduced a wrapper function `wrap_loss_fn` to adapt existing PyTorch loss functions (like `nn.BCEWithLogitsLoss`) to the new interface.
*   Updated the `get_loss_fn` function to return loss functions wrapped by `wrap_loss_fn`.
*   Modified the `train_one_epoch` and `valid_one_epoch` functions to retrieve the loss value according to the changed loss function interface (`loss = criterion(...)` -> `loss = criterion(...)["loss"]`).

## Impact

*   **Configuration**: Code using `ema_params` from `Config` will be affected by the key name change to `decay`.
*   **Data Loading**: Callers of `init_dataloader` can now specify the new arguments (`prefetch_factor`, `persistent_workers`). The removal of worker-specific seeding might affect the reproducibility of behavior between runs (especially concerning data augmentation).
*   **Models**: Code defining custom models using `timm` needs to follow `timm`'s API changes (addressed in this PR).
*   **Loss Calculation**: All parts of the code that retrieve or use the loss function (callers of `get_loss_fn`, execution points of `criterion`) are affected by the new interface (dictionary return format).